### PR TITLE
Updated PA__ResizeArray

### DIFF
--- a/4D Plugin API/4DPluginAPI.c
+++ b/4D Plugin API/4DPluginAPI.c
@@ -4503,11 +4503,11 @@ void PA_ResizeArray( PA_Variable *ar, PA_long32 nb )
 				// if array become smaller
 				if ( nb < ar->uValue.fArray.fNbElements )
 				{
-					PA_Blob** ptBlobHandle = (PA_Blob**) PA_LockHandle( ar->uValue.fArray.fData );
+					PA_Blob* ptBlobHandle = (PA_Blob*) PA_LockHandle( ar->uValue.fArray.fData );
 
 					for ( i = nb + 1; i <= ar->uValue.fArray.fNbElements; i++ )
 					{
-						PA_DisposeHandle(ptBlobHandle[i]->fHandle);
+						PA_DisposeHandle(ptBlobHandle[i].fHandle);
 					}
 					
 					PA_UnlockHandle( ar->uValue.fArray.fData );


### PR DESCRIPTION
If an ARRAY BLOB had a size and PA_ResizeArray was called an error would occur, updated the code to correctly dispose of the elements in the array.